### PR TITLE
fix: coerce NodeList to an array before iterating

### DIFF
--- a/src/sparkline.js
+++ b/src/sparkline.js
@@ -3,7 +3,7 @@ function getY(max, height, diff, value) {
 }
 
 function removeChildren(svg) {
-  svg.querySelectorAll("*").forEach(element => svg.removeChild(element));
+  [...svg.querySelectorAll("*")].forEach(element => svg.removeChild(element));
 }
 
 function defaultFetch(entry) {


### PR DESCRIPTION
`NodeList`s only recently grew a `forEach` method.  This copies the result of `querySelectorAll` into a new array so we can use forEach with it in a wider set of browsers. 