### PR TITLE
Export modern JavaScript

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   ],
   "main": "dist/sparkline.js",
   "module": "dist/sparkline.commonjs2.js",
+  "exports": "src/sparkline.js",
   "scripts": {
     "test": "mocha --require @babel/register \"test/**/*_test.js\"",
     "js:dist:commonjs2": "LIBRARY_TARGET=commonjs2 webpack",


### PR DESCRIPTION
For those that install via npm and want to ship out modern JavaScript code, I think you can add `exports` in `package.json`