### PR TITLE
prevent division by zero when calculating y values

### DIFF
--- a/src/sparkline.js
+++ b/src/sparkline.js
@@ -1,4 +1,5 @@
 function getY(max, height, diff, value) {
+  if (max === 0) return height * 1.0
   return parseFloat((height - (value * height / max) + diff).toFixed(2));
 }
 

--- a/test/sparkline_test.js
+++ b/test/sparkline_test.js
@@ -31,6 +31,12 @@ describe("sparkline", () => {
     snapshot(svg.outerHTML);
   });
 
+  it("renders svg with entirely 0-based values", () => {
+    const svg = createSVG(100, 30, 2);
+    sparkline(svg, [0, 0, 0, 0, 0]);
+    snapshot(svg.outerHTML);
+  });
+
   it("renders svg for 1-item array", () => {
     const svg = createSVG(100, 30, 2);
     sparkline(svg, [5]);


### PR DESCRIPTION
calling getY() with 0 value would produce NaN which are invalid in svg where those end up. in that case, the added condition returns the height in float to draw a data point at y=0.

related #13, closes #24, fixes #14